### PR TITLE
Add helper script for host PC to exec commands in Docker.

### DIFF
--- a/docker/mydocker/ubuntu/README.md
+++ b/docker/mydocker/ubuntu/README.md
@@ -87,3 +87,12 @@ docker logout
 ```
 docker-compose up -d
 ```
+
+## docker内でコマンドを実行する
+
+`man docker-exec`参照。
+
+`source helper.sh`で`de`をaliasを定義できる。
+
+* `de` : docker内でbash起動
+* `de 任意のコマンド` : docker内でコマンドを実行

--- a/docker/mydocker/ubuntu/README.md
+++ b/docker/mydocker/ubuntu/README.md
@@ -41,7 +41,7 @@ localhost:6081
 Terminalを2つ用意してそれぞれで以下を実行
 
 ```
-cd ~/catkin_make/src/burger_war_kit
+cd ~/catkin_ws/src/burger_war_kit
 bash scripts/sim_with_judge.sh
 ```
 

--- a/docker/mydocker/ubuntu/README.md
+++ b/docker/mydocker/ubuntu/README.md
@@ -92,7 +92,7 @@ docker-compose up -d
 
 `man docker-exec`参照。
 
-`source helper.sh`で`de`をaliasを定義できる。
+`source helper.sh`で`de`というaliasを定義できる。
 
 * `de` : docker内でbash起動
 * `de 任意のコマンド` : docker内でコマンドを実行

--- a/docker/mydocker/ubuntu/docker-compose.yml
+++ b/docker/mydocker/ubuntu/docker-compose.yml
@@ -7,3 +7,7 @@ services:
      ports:
       - "6081:80"
      shm_size: '512m'
+     volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix
+     environment:
+      - DISPLAY=unix${DISPLAY}

--- a/docker/mydocker/ubuntu/helper.sh
+++ b/docker/mydocker/ubuntu/helper.sh
@@ -1,0 +1,17 @@
+function my_docker_exec() {
+  local DOCKER_USER="$1"
+  local CONTAINER="$2"
+  local COMMANDS="$3"
+  local WORKING_DIR="/home/${DOCKER_USER}"
+
+  if [ -z "${COMMANDS}" ]; then
+    COMMANDS=/bin/bash
+  fi
+
+  docker exec -it -u ${DOCKER_USER} -w ${WORKING_DIR} ${CONTAINER} ${COMMANDS}
+}
+
+function de() {
+  COMMANDS="$*"
+  my_docker_exec ubuntu burger_war_docker "${COMMANDS}"
+}


### PR DESCRIPTION
@seigot 
docker exec hogehogeを打つのが辛いので、ヘルパースクリプトを登録させてほしいです。
各自環境の.bashrcでこのスクリプトをsourceするイメージです。
とここまで書いてREADMEにも追記するべきな気がしてきましたので追記します。