### PR TITLE
[chore] Specify docker hostname for debuggability.

### DIFF
--- a/docker/mydocker/ubuntu/docker-compose.yml
+++ b/docker/mydocker/ubuntu/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   myproject:
      image: seigott/burger_war_docker
      container_name: burger_war_docker
+     hostname: ${USER}-docker
      ports:
       - "6081:80"
      shm_size: '512m'


### PR DESCRIPTION
@seigot 
autotestの結果に、どの環境での結果かの情報がほしいと考えてます。

hostnameが良いような気がするのですが、docker環境だとdefault hash値なので、
docker環境のhostnameを指定するようにしません？

一番いいのはhost PCのhostnameベースでdocker環境のhostnameを決めることかと思いますが、
どうやらdocker-composeのyaml内でshellコマンドの結果は素直には使えないらしく、
host PCのuser名ベースでdocker環境のhostnameを決めるようにしてみました。

ご意見いただければ幸いです。